### PR TITLE
Add ipaddress gem to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,4 @@ end
 gem "docopt"
 gem "ruby-ip"
 gem "open4"
+gem "ipaddress"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     docopt (0.5.0)
+    ipaddress (0.8.3)
     open4 (1.3.4)
     ruby-ip (0.9.3)
 
@@ -11,8 +12,9 @@ PLATFORMS
 DEPENDENCIES
   bundler
   docopt
+  ipaddress
   open4
   ruby-ip
 
 BUNDLED WITH
-   1.10.6
+   1.15.4


### PR DESCRIPTION
This pull request adds `ipaddress` gem to `Gemfile`, it is used but not listed (only in README).